### PR TITLE
add resources contact contributing

### DIFF
--- a/docs/contact.md
+++ b/docs/contact.md
@@ -1,0 +1,10 @@
+---
+name: Contact
+route: /contact
+---
+
+# Contact
+
+---
+
+Feel free to join us for a chat in our [Gitter chat room](https://gitter.im/City-of-Helsinki/heldev).

--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -1,0 +1,9 @@
+---
+name: Contribute
+route: /contribute
+---
+# Contribute
+
+---
+
+Found a bug? Is some of the documentation outdated? The source code for this site is available on [GitHub](https://github.com/City-of-Helsinki/bestpractice) for anyone to contribute to. See our [practices on accepting contributions](https://github.com/City-of-Helsinki/bestpractice/blob/master/.github/contributing.md).

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,8 +1,10 @@
 ---
-name: Helsinki Developers
+name: ' '
 route: /
 ---
 # Develop with Helsinki
+
+---
 
 This site covers the practical details for developing open source code for the City of Helsinki. The target audience is software development consultants working for Helsinki codebases, Helsinki software development staff, and people offering contributions to Helsinki software. The documentation is produced jointly by the software developers of the Executive Office and the divisions of the city.
 
@@ -13,3 +15,7 @@ Topics such as [coding standards](/coding-standards), [technology choices](/tech
 ### API documentation
 
 Here you will find documentation for several City of Helsinki open APIs that cover [services](apis/servicemap), [events](apis/linkedevents), [decision-making](apis/openahjo), [bookable rooms and equipment](apis/respa) and [reporting issues and giving feedback](apis/open311).
+
+### Resources
+
+Useful resources for developers include [Helsinki Design System](https://city-of-helsinki.github.io/helsinki-design-system/), [Helsinki guidelines for user driver digital service development](https://digi.hel.fi/digipalveluopas/periaatteet/) (in Finnish) and [Helsinki best practices for IT development](https://kehmet.hel.fi/) (in Finnish).

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -1,0 +1,13 @@
+---
+name: Resources
+route: /resources
+---
+
+# Resources
+
+---
+
+Useful resources for developers
+- [Helsinki Design System](https://city-of-helsinki.github.io/helsinki-design-system/)
+- [Helsinki guidelines for user driver digital service development (in Finnish)](https://digi.hel.fi/digipalveluopas/periaatteet/)
+- [Helsinki best practices for IT development (in Finnish)](https://kehmet.hel.fi/)

--- a/doczrc.js
+++ b/doczrc.js
@@ -8,9 +8,11 @@ const themeConfig = {
 };
 
 const menu = [
-  "Helsinki Developers",
-  "APIs",
   "Best practices",
+  "APIs",
+  "Resources",
+  "Contribute", 
+  "Contact"
 ];
 
 export default {


### PR DESCRIPTION
## Description :sparkles:
- add resources.md that links to HDS etc.
- add resources to front page
- add contact.md that links to Gitter
- add contribute.md that links to source
- hide additional front page link from menu as it was redundant as it can be accessed by clicking the logo or "Developers"