### PR TITLE
add project pages to fix external links

### DIFF
--- a/docs/projects/README.md
+++ b/docs/projects/README.md
@@ -1,0 +1,3 @@
+# Legacy project documentation
+
+These files are kept here in order to not break links that refer to the old dev.hel.fi project pages. Do not add any new service or project documentation here!

--- a/docs/projects/decidim-helsinki.md
+++ b/docs/projects/decidim-helsinki.md
@@ -1,0 +1,10 @@
+---
+name: ' '
+route: /projects/decidim-helsinki
+---
+
+# Nothing to see here! 👀
+
+The project pages are no longer maintained on the new dev.hel.fi site.
+
+You can visit the old project page at [dev.hel.ninja](https://dev.hel.ninja/projects/decidim-helsinki).

--- a/docs/projects/devhel.fi.md
+++ b/docs/projects/devhel.fi.md
@@ -1,0 +1,10 @@
+---
+name: ' '
+route: /projects/devhelfi
+---
+
+# Nothing to see here! 👀
+
+The project pages are no longer maintained on the new dev.hel.fi site.
+
+You can visit the old project page at [dev.hel.ninja](https://dev.hel.ninja/projects/devhelfi).

--- a/docs/projects/geoserver-preview.md
+++ b/docs/projects/geoserver-preview.md
@@ -1,0 +1,10 @@
+---
+name: ' '
+route: /projects/geoserver-preview
+---
+
+# Nothing to see here! 👀
+
+The project pages are no longer maintained on the new dev.hel.fi site.
+
+You can visit the old project page at [dev.hel.ninja](https://dev.hel.ninja/projects/geoserver-preview).

--- a/docs/projects/helsinki-app.md
+++ b/docs/projects/helsinki-app.md
@@ -1,0 +1,10 @@
+---
+name: ' '
+route: /projects/helsinki-app
+---
+
+# Nothing to see here! 👀
+
+The project pages are no longer maintained on the new dev.hel.fi site.
+
+You can visit the old project page at [dev.hel.ninja](https://dev.hel.ninja/projects/helsinki-app).

--- a/docs/projects/helsinki-ckan.md
+++ b/docs/projects/helsinki-ckan.md
@@ -1,0 +1,10 @@
+---
+name: ' '
+route: /projects/helsinki-ckan
+---
+
+# Nothing to see here! 👀
+
+The project pages are no longer maintained on the new dev.hel.fi site.
+
+You can visit the old project page at [dev.hel.ninja](https://dev.hel.ninja/projects/helsinki-ckan).

--- a/docs/projects/kerro-kantasi.md
+++ b/docs/projects/kerro-kantasi.md
@@ -1,0 +1,10 @@
+---
+name: ' '
+route: /projects/kerro-kantasi
+---
+
+# Nothing to see here! 👀
+
+The project pages are no longer maintained on the new dev.hel.fi site.
+
+You can visit the old project page at [dev.hel.ninja](https://dev.hel.ninja/projects/kerro-kantasi).

--- a/docs/projects/koulurekisteri.md
+++ b/docs/projects/koulurekisteri.md
@@ -1,0 +1,10 @@
+---
+name: ' '
+route: /projects/koulurekisteri
+---
+
+# Nothing to see here! 👀
+
+The project pages are no longer maintained on the new dev.hel.fi site.
+
+You can visit the old project page at [dev.hel.ninja](https://dev.hel.ninja/projects/koulurekisteri).

--- a/docs/projects/linked-courses.md
+++ b/docs/projects/linked-courses.md
@@ -1,0 +1,10 @@
+---
+name: ' '
+route: /projects/linked-courses
+---
+
+# Nothing to see here! 👀
+
+The project pages are no longer maintained on the new dev.hel.fi site.
+
+You can visit the old project page at [dev.hel.ninja](https://dev.hel.ninja/projects/linked-courses).

--- a/docs/projects/linked-events.md
+++ b/docs/projects/linked-events.md
@@ -1,0 +1,10 @@
+---
+name: ' '
+route: /projects/linked-events
+---
+
+# Nothing to see here! 👀
+
+The project pages are no longer maintained on the new dev.hel.fi site.
+
+You can visit the old project page at [dev.hel.ninja](https://dev.hel.ninja/projects/linked-events).

--- a/docs/projects/luontotietojarjestelma.md
+++ b/docs/projects/luontotietojarjestelma.md
@@ -1,0 +1,10 @@
+---
+name: ' '
+route: /projects/ltj
+---
+
+# Nothing to see here! 👀
+
+The project pages are no longer maintained on the new dev.hel.fi site.
+
+You can visit the old project page at [dev.hel.ninja](https://dev.hel.ninja/projects/ltj).

--- a/docs/projects/maanvuokrajarjestelma.md
+++ b/docs/projects/maanvuokrajarjestelma.md
@@ -1,0 +1,10 @@
+---
+name: ' '
+route: /projects/maanvuokrajarjestelma
+---
+
+# Nothing to see here! 👀
+
+The project pages are no longer maintained on the new dev.hel.fi site.
+
+You can visit the old project page at [dev.hel.ninja](https://dev.hel.ninja/projects/maanvuokrajarjestelma).

--- a/docs/projects/open-city-profile.md
+++ b/docs/projects/open-city-profile.md
@@ -1,0 +1,10 @@
+---
+name: ' '
+route: /projects/open-city-profile
+---
+
+# Nothing to see here! 👀
+
+The project pages are no longer maintained on the new dev.hel.fi site.
+
+You can visit the old project page at [dev.hel.ninja](https://dev.hel.ninja/projects/open-city-profile).

--- a/docs/projects/openahjo.md
+++ b/docs/projects/openahjo.md
@@ -1,0 +1,10 @@
+---
+name: ' '
+route: /projects/openahjo
+---
+
+# Nothing to see here! 👀
+
+The project pages are no longer maintained on the new dev.hel.fi site.
+
+You can visit the old project page at [dev.hel.ninja](https://dev.hel.ninja/projects/openahjo).

--- a/docs/projects/palautebot.md
+++ b/docs/projects/palautebot.md
@@ -1,0 +1,10 @@
+---
+name: ' '
+route: /projects/palautebot
+---
+
+# Nothing to see here! 👀
+
+The project pages are no longer maintained on the new dev.hel.fi site.
+
+You can visit the old project page at [dev.hel.ninja](https://dev.hel.ninja/projects/palautebot).

--- a/docs/projects/respa.md
+++ b/docs/projects/respa.md
@@ -1,0 +1,10 @@
+---
+name: ' '
+route: /projects/respa-resource
+---
+
+# Nothing to see here! 👀
+
+The project pages are no longer maintained on the new dev.hel.fi site.
+
+You can visit the old project page at [dev.hel.ninja](https://dev.hel.ninja/projects/respa-resource).

--- a/docs/projects/service-map.md
+++ b/docs/projects/service-map.md
@@ -1,0 +1,10 @@
+---
+name: ' '
+route: /projects/service-map
+---
+
+# Nothing to see here! 👀
+
+The project pages are no longer maintained on the new dev.hel.fi site.
+
+You can visit the old project page at [dev.hel.ninja](https://dev.hel.ninja/projects/service-map).

--- a/docs/projects/stadin-tilapankki.md
+++ b/docs/projects/stadin-tilapankki.md
@@ -1,0 +1,10 @@
+---
+name: ' '
+route: /projects/stadin-tilapankki
+---
+
+# Nothing to see here! 👀
+
+The project pages are no longer maintained on the new dev.hel.fi site.
+
+You can visit the old project page at [dev.hel.ninja](https://dev.hel.ninja/projects/stadin-tilapankki).

--- a/docs/projects/tiedonohjausjarjestelma.md
+++ b/docs/projects/tiedonohjausjarjestelma.md
@@ -1,0 +1,10 @@
+---
+name: ' '
+route: /projects/tiedonohjausjarjestelma
+---
+
+# Nothing to see here! 👀
+
+The project pages are no longer maintained on the new dev.hel.fi site.
+
+You can visit the old project page at [dev.hel.ninja](https://dev.hel.ninja/projects/tiedonohjausjarjestelma).

--- a/docs/projects/varaamo.md
+++ b/docs/projects/varaamo.md
@@ -1,0 +1,10 @@
+---
+name: ' '
+route: /projects/varaamo
+---
+
+# Nothing to see here! 👀
+
+The project pages are no longer maintained on the new dev.hel.fi site.
+
+You can visit the old project page at [dev.hel.ninja](https://dev.hel.ninja/projects/varaamo).


### PR DESCRIPTION
## Description :sparkles:
Add simple pages for projects that used to exist on the old dev.hel.fi so that external links are not broken. Includes a link to the old dev.hel.fi.