### PR TITLE
add matomo analytics

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,0 +1,12 @@
+module.exports = {
+    plugins: [
+      {
+        resolve: 'gatsby-plugin-matomo',
+        options: {
+          siteId: '6',
+          matomoUrl: 'https://analytics.hel.ninja/',
+          siteUrl: 'https://dev.hel.fi/',
+        },
+      },
+    ],
+  };

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -3,7 +3,7 @@ module.exports = {
       {
         resolve: 'gatsby-plugin-matomo',
         options: {
-          siteId: '6',
+          siteId: 6,
           matomoUrl: 'https://analytics.hel.ninja/',
           siteUrl: 'https://dev.hel.fi/',
         },

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "swagger-ui-react": "^3.25.0"
   },
   "devDependencies": {
+    "gatsby-plugin-matomo": "^0.8.3",
     "hds-core": "0.4.1",
     "hds-react": "0.5.4",
     "react-helmet": "^5.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5598,6 +5598,11 @@ gatsby-plugin-manifest@^2.2.3:
     semver "^5.7.1"
     sharp "^0.23.2"
 
+gatsby-plugin-matomo@^0.8.3:
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-matomo/-/gatsby-plugin-matomo-0.8.3.tgz#e0e9cc9e60f7e4b157c9964dfc9d444d73bc46ee"
+  integrity sha512-fv6TgD+WsxziZrtmz6sNF4m9FgSyV+8y3R1sobA5hB5OxJyhs/Y4HVo9jCPRHu5VLKQsg4i7LJhWL0ocJiqEWQ==
+
 gatsby-plugin-mdx@^1.0.13:
   version "1.0.55"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-mdx/-/gatsby-plugin-mdx-1.0.55.tgz#fa7fc24216e4d71df303160314ee5e6dab2c83e8"


### PR DESCRIPTION
## Description :sparkles:
- adds Matomo analytics tracking to site
- however, something is not quite right with this, since visits do not end up tracked on Matomo. This PR is similar to this PR for the HDS site. So I'll just leave this here for someone else to pick up.

### Closes :no_good_woman:
**[DEV-17](https://helsinkisolutionoffice.atlassian.net/browse/DEV-17)** 

## Testing :alembic:
### Manual testing :construction_worker_man:
This can be tested locally by adding `dev: true` to `options` in `gatsby-config.js`

## Additional notes :spiral_notepad:
https://www.gatsbyjs.org/packages/gatsby-plugin-matomo/
https://www.docz.site/docs/powered-by-gatsby
