### PR TITLE
fix redirect links

### DIFF
--- a/accepting-contributions.md
+++ b/accepting-contributions.md
@@ -3,4 +3,4 @@
 
 [Document moved here](docs/accepting-contributions.md)
 
-[Document on Helsinki Developers](https://developer.hel.ninja/accepting-contributions) (under construction)
+[Document on Helsinki Developers](https://dev.hel.fi/accepting-contributions)

--- a/django-configuration.md
+++ b/django-configuration.md
@@ -3,4 +3,4 @@
 
 [Document moved here](docs/django-configuration.md)
 
-[Document on Helsinki Developers](https://developer.hel.ninja/django-configuration) (under construction)
+[Document on Helsinki Developers](https://dev.hel.fi/django-configuration)

--- a/maps.md
+++ b/maps.md
@@ -3,4 +3,4 @@
 
 [Document moved here](docs/maps.md)
 
-[Document on Helsinki Developers](https://developer.hel.ninja/maps) (under construction)
+[Document on Helsinki Developers](https://dev.hel.fi/maps)

--- a/scrum-project-management.md
+++ b/scrum-project-management.md
@@ -3,4 +3,4 @@
 
 [Document moved here](docs/scrum-project-management.md)
 
-[Document on Helsinki Developers](https://developer.hel.ninja/scrum-project-management) (under construction)
+[Document on Helsinki Developers](https://dev.hel.fi/scrum-project-management)

--- a/technology-choices.md
+++ b/technology-choices.md
@@ -3,4 +3,4 @@
 
 [Document moved here](docs/technology-choices.md)
 
-[Document on Helsinki Developers](https://developer.hel.ninja/technology-choices) (under construction)
+[Document on Helsinki Developers](https://dev.hel.fi/technology-choices)

--- a/version-control.md
+++ b/version-control.md
@@ -3,4 +3,4 @@
 
 [Document moved here](docs/version-control.md)
 
-[Document on Helsinki Developers](https://developer.hel.ninja/version-control) (under construction)
+[Document on Helsinki Developers](https://dev.hel.fi/version-control)


### PR DESCRIPTION
## Description :sparkles:
Fix the redirect links in the markdown files that exist in the old location in the repo to point to dev.hel.fi