### PR TITLE
linked events redirect

### DIFF
--- a/docs/apis/linked-events.md
+++ b/docs/apis/linked-events.md
@@ -1,0 +1,8 @@
+---
+name: ' '
+route: /apis/linked-events
+---
+
+# Linked Events API has moved
+
+Documentation can now be found at [https://dev.hel.fi/apis/linkedevents](/apis/linkedevents)


### PR DESCRIPTION
## Description :sparkles:
Google search result for Linked Events goes to /apis/linked-events. This fixes that missing page.