### PR TITLE
Link to Confluence wiki documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# :eyes: This repository is no longer maintained. Documentation has been moved to the [Confluence wiki](https://helsinkisolutionoffice.atlassian.net/wiki/spaces/OS/). :eyes:
+
+
+
 # Best practices for developing for City of Helsinki
 
 This documentation covers the practical details for developing open source code for the City of Helsinki. The target audience is software development consultants working for Helsinki codebases, Helsinki software development staff, and people offering contributions to Helsinki software. This documentation is produced jointly by the software developers of the Executive Office and the divisions of the city. Not all practices stated here will apply to all projects within the city but these are intended as general outlines of best practices.


### PR DESCRIPTION
## Description :sparkles:
Update readme to reflect that repo is no longer updated and link to Confluence.